### PR TITLE
Correction on searching Portuguese Subtitles

### DIFF
--- a/resources/lib/LegendasTV.py
+++ b/resources/lib/LegendasTV.py
@@ -382,7 +382,7 @@ class LegendasTV:
             TotalPages=3
             # Form and execute threaded downloads
             for Page in range(TotalPages):
-                Page += 1                
+                Page += 1
                 current = LTVThread(self, MainID , MainIDNumber, Page)
                 self.RegThreads.append(current)
                 current.start()


### PR DESCRIPTION
The search page wasn't getting all results. If you search like before, you don't get all subtitles, with new way you get all subtitles.
