### PR TITLE
Fix to download error in some stream addons

### DIFF
--- a/service.py
+++ b/service.py
@@ -64,7 +64,7 @@ def Search(item):  # standard input
             url = "plugin://%s/?action=download&download_url=%s&filename=%s" % (__scriptid__, it["url"],os.path.basename(item["file_original_path"]))
             xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=url,listitem=listitem,isFolder=False)
     
-def Download(url, filename='tempfilename', stack=False): #standard input
+def Download(url, filename, stack=False): #standard input
     #Create some variables
     subtitles = []
     extractPath = os.path.join(__temp__, "Extracted")
@@ -240,7 +240,8 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     Search(item)    
 
 elif params['action'] == 'download':
-    subs = Download(params["download_url"],params["filename"])
+    try: subs = Download(params["download_url"],params["filename"])
+    except: subs = Download(params["download_url"],'filename')
     for sub in subs:
         listitem = xbmcgui.ListItem(label2=os.path.basename(sub))
         xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=sub,listitem=listitem,isFolder=False)


### PR DESCRIPTION
Without this fix, on addon gomovies, for eg, when I try to download subtitles to "lone survivor" or avatar I get this error:
00:15:52 T:1560   DEBUG: ### [Legendas.TV] - Version: 2.2.1
00:15:52 T:1560   DEBUG: ### [Legendas.TV] - Action 'download' called
00:15:52 T:1560   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: ('filename',)
                                            Traceback (most recent call last):
                                              File "C:\Users\joana_000\AppData\Roaming\XBMC\addons\service.subtitles.legendastv\service.py", line 245, in <module>
                                                subs = Download(params["download_url"],params["filename"])
                                            KeyError: ('filename',)
                                            -->End of Python script error report<--

With this litle fix it downloads, I don't know if this is the best, but works.
