### PR TITLE
Unicode issue #17

### DIFF
--- a/service.py
+++ b/service.py
@@ -129,7 +129,7 @@ def Download(url, filename, pack, language): #standard input
     # Use XBMC.Extract to extract the downloaded file, extract it to the temp dir, 
     # then removes all files from the temp dir that aren't subtitles.
     def extract_and_copy(extraction=0):
-        for root, dirs, files in os.walk(extractPath, topdown=False):
+        for root, dirs, files in os.walk(unicode(extractPath, 'utf8'), topdown=False):
             for file in files:
                 dirfile = os.path.join(root, file)
                 


### PR DESCRIPTION
Fixed issue #17  with handling subtitles containing unicode characters, which could cause the plugin to break and require deleting temp folder.

As python uses the encoding of the first level of the path, it would presume ASCII, so "walk" should be forced to be unicode.

Eg subtitle: plugin://service.subtitles.legendastv/?action=download&download_url=http://legendas.tv/download/58cb0ae5e21ad/Why_Him/Why_Him_2016_1080p_BluRay_BRRip_BDRip_720p_WEB_DL_DVDRip_Subrip&filename=Why.Him.2016.BDRip.x264-GECKOS.mp4&pack=false&lang=Portuguese