### PR TITLE
Handling non-ascii content on log method

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
    id="service.subtitles.legendastv"
    name="Legendas.TV"
-   version="2.3.2"
+   version="2.4.0"
    provider-name="gfjardim">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+2.4.0
+- Fix: Use RAR Archive support addon on Koki 18 (by henricos) 
+
 2.3.2
 - Fix: addon version mismatch 
 

--- a/resources/lib/LTVutilities.py
+++ b/resources/lib/LTVutilities.py
@@ -34,7 +34,13 @@ def log(msg, logtype="DEBUG"):
   if   logtype == "DEBUG":   loglevel = xbmc.LOGDEBUG
   elif logtype == "NOTICE":  loglevel = xbmc.LOGNOTICE
   elif logtype == "ERROR":   loglevel = xbmc.LOGERROR
-  xbmc.log((u"### [%s] - %s" % (__scriptname__,msg,)).encode('utf-8'), level=loglevel )
+  reload(sys)
+  defaultencoding = sys.getdefaultencoding()
+  sys.setdefaultencoding('utf-8')
+  try:
+    xbmc.log((u"### [%s] - %s" % (__scriptname__,msg,)).encode('utf-8'), level=loglevel )
+  finally:
+    sys.setdefaultencoding(defaultencoding)
 
 def getTheTVDBToken():
     HTTPRequest = urllib2.Request("https://api.thetvdb.com/login", data=json.dumps({"apikey" : TheTVDBApi}), headers={'Content-Type' : 'application/json'})

--- a/resources/lib/LTVutilities.py
+++ b/resources/lib/LTVutilities.py
@@ -181,3 +181,15 @@ def isStacked(subA, subB):
                 if fnA == fnB and otherA == otherB:
                     return True
     return False
+
+def extractArchiveToFolder(archive, ext, destFolder):
+    archiveURL = urllib.quote_plus(archive)
+    if ext == 'rar':
+        archiveURL = 'rar://' + archiveURL
+    else:
+        archiveURL = 'zip://' + archiveURL
+    dirs, files = xbmcvfs.listdir(archiveURL)
+    for file in files:
+        src = archiveURL + '/' + file
+        dest = destFolder + '/' + file
+        xbmcvfs.copy(src, dest)

--- a/resources/lib/LTVutilities.py
+++ b/resources/lib/LTVutilities.py
@@ -8,6 +8,7 @@ import xbmcvfs
 import shutil
 import unicodedata
 import urllib, urllib2
+import ssl
 
 try: import simplejson as json
 except: import json
@@ -160,7 +161,8 @@ def getTVShowOrginalTitle(Title, ShowID):
 def getMovieOriginalTitle(Title, MovieID):
     if MovieID:
       HTTPRequest  = urllib2.Request("https://api.themoviedb.org/3/find/%s?external_source=imdb_id&api_key=%s" % (MovieID, TMDBApi))
-      HTTPResponse = urllib2.urlopen(HTTPRequest).read()
+      context = ssl._create_unverified_context()
+      HTTPResponse = urllib2.urlopen(HTTPRequest, context=context).read()
       JSONContent  = json.loads(HTTPResponse);
       if len(JSONContent["movie_results"]):
         return normalizeString(JSONContent["movie_results"][0]['original_title'].encode('utf-8'))

--- a/service.py
+++ b/service.py
@@ -2,7 +2,7 @@
 # Copyright, 2010, Guilherme Jardim.
 # This program is distributed under the terms of the GNU General Public License, version 3.
 # http://www.gnu.org/licenses/gpl.txt
-# Rev. 2.3.2
+# Rev. 2.4.0
 
 import os
 import sys
@@ -31,7 +31,7 @@ __search__   = __addon__.getSetting( 'SEARCH' )
 __username__ = __addon__.getSetting( 'USERNAME' )
 __password__ = __addon__.getSetting( 'PASSWORD' )
 
-from LTVutilities import log, cleanDirectory, isStacked, getMovieIMDB, getShowIMDB, getShowId, getTVShowOrginalTitle, getMovieOriginalTitle, safeFilename
+from LTVutilities import log, cleanDirectory, isStacked, getMovieIMDB, getShowIMDB, getShowId, getTVShowOrginalTitle, getMovieOriginalTitle, safeFilename, extractArchiveToFolder
 from LegendasTV import *
 
 LTV = LegendasTV()
@@ -157,7 +157,8 @@ def Download(url, filename, pack, language): #standard input
                         subtitles.append(new_dirfile)
                 elif ext in "rar zip" and not extraction:
                     # Extract compressed files, extracted priorly
-                    xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (new_dirfile, extractPath))
+                    #xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (new_dirfile, extractPath))
+                    extractArchiveToFolder(new_dirfile, ext, extractPath)
                     xbmc.sleep(1000)
                     extract_and_copy(1)
                 elif ext not in "idx": xbmcvfs.delete(new_dirfile)
@@ -165,7 +166,8 @@ def Download(url, filename, pack, language): #standard input
                 dirfolder = os.path.join(root, dir)
                 xbmcvfs.rmdir(dirfolder)
 
-    xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (fname, extractPath))
+    #xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (fname, extractPath))
+    extractArchiveToFolder(fname, FileExt, extractPath)
     xbmc.sleep(1000)
     extract_and_copy()
     


### PR DESCRIPTION
Hi,

On my FireTV, sometimes I got error from LegendasTV plugin, with the following log content:

```
23:25:12.034 T:367988811952   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnicodeDecodeError'>
                                            Error Contents: 'ascii' codec can't decode byte 0xe2 in position 214: ordinal not in range(128)
                                            Traceback (most recent call last):
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/service.subtitles.legendastv/service.py", line 321, in <module>
                                                subs = Download(params["download_url"],'filename', pack, params['lang'])
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/service.subtitles.legendastv/service.py", line 170, in Download
                                                extract_and_copy()
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/service.subtitles.legendastv/service.py", line 137, in extract_and_copy
                                                log("Opening file: "+dirfile, "DEBUG")
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/service.subtitles.legendastv/resources/lib/LTVutilities.py", line 37, in log
                                                xbmc.log((u"### [%s] - %s" % (__scriptname__,msg,)).encode('utf-8'), level=loglevel )
                                            UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 214: ordinal not in range(128)
                                            -->End of Python script error report<--
23:25:12.134 T:367990317696   ERROR: GetDirectory - Error getting plugin://service.subtitles.legendastv/?action=download&download_url=http://legendas.tv/download/59da3c342b07d/The_Dark_Tower/The_Dark_Tower_2017_BluRay_BDRip_BRRip&filename=The.Dark.Tower.2017.1080p.BluRay.DTS.X264.mkv&pack=false&lang=Portuguese (Brazil)
```

It seems to be related for python processing string formatting operation using ASCII encoding. I was able to fix it locally with the changed code. 