### PR TITLE
Fix RAR extraction on Kodi 18

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
    id="service.subtitles.legendastv"
    name="Legendas.TV"
-   version="2.3.2"
+   version="2.4.0"
    provider-name="gfjardim">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+2.4.0
+- Fix: Use RAR Archive support addon on Koki 18 (by henricos) 
+
 2.3.2
 - Fix: addon version mismatch 
 

--- a/resources/lib/LTVutilities.py
+++ b/resources/lib/LTVutilities.py
@@ -175,3 +175,15 @@ def isStacked(subA, subB):
                 if fnA == fnB and otherA == otherB:
                     return True
     return False
+
+def extractArchiveToFolder(archive, ext, destFolder):
+    archiveURL = urllib.quote_plus(archive)
+    if ext == 'rar':
+        archiveURL = 'rar://' + archiveURL
+    else:
+        archiveURL = 'zip://' + archiveURL
+    dirs, files = xbmcvfs.listdir(archiveURL)
+    for file in files:
+        src = archiveURL + '/' + file
+        dest = destFolder + '/' + file
+        xbmcvfs.copy(src, dest)

--- a/service.py
+++ b/service.py
@@ -2,7 +2,7 @@
 # Copyright, 2010, Guilherme Jardim.
 # This program is distributed under the terms of the GNU General Public License, version 3.
 # http://www.gnu.org/licenses/gpl.txt
-# Rev. 2.3.2
+# Rev. 2.4.0
 
 import os
 import sys
@@ -31,7 +31,7 @@ __search__   = __addon__.getSetting( 'SEARCH' )
 __username__ = __addon__.getSetting( 'USERNAME' )
 __password__ = __addon__.getSetting( 'PASSWORD' )
 
-from LTVutilities import log, cleanDirectory, isStacked, getMovieIMDB, getShowIMDB, getShowId, getTVShowOrginalTitle, getMovieOriginalTitle, safeFilename
+from LTVutilities import log, cleanDirectory, isStacked, getMovieIMDB, getShowIMDB, getShowId, getTVShowOrginalTitle, getMovieOriginalTitle, safeFilename, extractArchiveToFolder
 from LegendasTV import *
 
 LTV = LegendasTV()
@@ -157,7 +157,8 @@ def Download(url, filename, pack, language): #standard input
                         subtitles.append(new_dirfile)
                 elif ext in "rar zip" and not extraction:
                     # Extract compressed files, extracted priorly
-                    xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (new_dirfile, extractPath))
+                    #xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (new_dirfile, extractPath))
+                    extractArchiveToFolder(new_dirfile, ext, extractPath)
                     xbmc.sleep(1000)
                     extract_and_copy(1)
                 elif ext not in "idx": xbmcvfs.delete(new_dirfile)
@@ -165,7 +166,8 @@ def Download(url, filename, pack, language): #standard input
                 dirfolder = os.path.join(root, dir)
                 xbmcvfs.rmdir(dirfolder)
 
-    xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (fname, extractPath))
+    #xbmc.executebuiltin("XBMC.Extract(%s, %s)" % (fname, extractPath))
+    extractArchiveToFolder(fname, FileExt, extractPath)
     xbmc.sleep(1000)
     extract_and_copy()
     


### PR DESCRIPTION
Since XBMC.Extract is deprecated on Kodi 18, all file manipulation must be done using the Vitrual File System (vfs) API

Changed version to 2.4.0 to be exclusive for Kodi 18.
Future fixes for Kodi 17 must be done in 2.3.X
Shouldn't this be a new branch?

From now on, RAR Archive support addon must be enabled.
Can it be done automatically on this addon installation?

